### PR TITLE
fix: uncomment PyPi release code

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -64,20 +64,19 @@ jobs:
           polling_interval_seconds: 5
           command: pip index versions --index-url https://test.pypi.org/simple/ transcriptformer | grep "Available.*${{ steps.get_version.outputs.VERSION }}"
 
-      # TODO: Once the repo is public, uncomment the following and remove the test token
-      # - name: Publish to PyPI
-      #   uses: pypa/gh-action-pypi-publish@release/v1
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
 
-      # - name: Confirm publish to PyPI
-      #   uses: nick-fields/retry@v3
-      #   with:
-      #     max_attempts: 15
-      #     timeout_seconds: 30
-      #     polling_interval_seconds: 5
-      #     command: pip index versions transcriptformer | grep "Available.*${{ steps.get_version.outputs.VERSION }}"
+      - name: Confirm publish to PyPI
+        uses: nick-fields/retry@v3
+        with:
+          max_attempts: 15
+          timeout_seconds: 30
+          polling_interval_seconds: 5
+          command: pip index versions transcriptformer | grep "Available.*${{ steps.get_version.outputs.VERSION }}"
 
-      # - name: Install and Test Package from PyPI
-      #   run: |
-      #     pip install --no-cache-dir transcriptformer
-      #     python -c "import transcriptformer"
-      #     pip freeze | grep "transcriptformer==${{ steps.get_version.outputs.VERSION }}"
+      - name: Install and Test Package from PyPI
+        run: |
+          pip install --no-cache-dir transcriptformer
+          python -c "import transcriptformer"
+          pip freeze | grep "transcriptformer==${{ steps.get_version.outputs.VERSION }}"


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish-pypi.yml` file to enable publishing the `transcriptformer` package to the public PyPI repository. The changes involve uncommenting previously commented steps in the workflow to finalize the publishing process.

### Workflow updates for publishing to PyPI:

* Enabled the `Publish to PyPI` step by uncommenting the `pypa/gh-action-pypi-publish@release/v1` action, allowing the package to be published to the public PyPI repository.
* Enabled the `Confirm publish to PyPI` step by uncommenting the `nick-fields/retry@v3` action, which verifies that the published version is available on PyPI.
* Enabled the `Install and Test Package from PyPI` step to ensure the published package can be installed and imported successfully, and that the correct version is available.