### PR TITLE
chore: remove testpypi publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -49,21 +49,6 @@ jobs:
       - name: Validate distribution files
         run: twine check dist/*
 
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # TODO: Once the repo is public, switch to publishing via Trusted Publisher and remove the test token
-          password: ${{ secrets.TEST_PYPI_CZI_API_TOKEN }}
-          repository-url: https://test.pypi.org/legacy/
-
-      - name: Confirm publish to Test PyPI
-        uses: nick-fields/retry@v3
-        with:
-          max_attempts: 15
-          timeout_seconds: 30
-          polling_interval_seconds: 5
-          command: pip index versions --index-url https://test.pypi.org/simple/ transcriptformer | grep "Available.*${{ steps.get_version.outputs.VERSION }}"
-
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 


### PR DESCRIPTION
This pull request simplifies the PyPI publishing workflow by removing the steps related to publishing to TestPyPI and confirming the publish. The workflow now directly publishes to the main PyPI repository.

### Workflow simplification:

* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bL52-L66): Removed the steps for publishing to TestPyPI, including the use of a test token and the confirmation step using the `nick-fields/retry` action. The workflow now skips the TestPyPI stage and directly publishes to PyPI.