### PR TITLE
chore: add id-token write to pypi-publish.yml

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -9,9 +9,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     # TODO: Once the repo is public, uncomment the following and remove the test token
-    # environment: pypi
-    # permissions:
-    #   id-token: write # to authenticate as Trusted Publisher to pypi.org
+    environment: pypi
+    permissions:
+      id-token: write # to authenticate as Trusted Publisher to pypi.org
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish-pypi.yml` file to enable publishing to PyPI as a Trusted Publisher. The most notable change involves uncommenting and activating the environment and permissions configuration for PyPI.

Workflow configuration changes:

* [`.github/workflows/publish-pypi.yml`](diffhunk://#diff-d4585bdbbb00b46a400628c271f195eb312333d18474299152a0b75fb1a7ec4bL12-R14): Enabled the `environment` and `permissions` settings for the `publish` job, allowing the repository to authenticate as a Trusted Publisher to PyPI.