### PR TITLE
fix: add back conf and scripts to root of repo

### DIFF
--- a/conf/inference_config.yaml
+++ b/conf/inference_config.yaml
@@ -1,0 +1,34 @@
+defaults:
+  - _self_ # Load the current config file
+
+model:
+  checkpoint_path: null # Path to the model checkpoint directory
+
+  inference_config: # inference settings
+    _target_: transcriptformer.data.dataclasses.InferenceConfig
+    batch_size: 8 # Number of samples to process in each batch
+    output_keys:
+      - embeddings # Include cell embeddings in the output
+      # - llh # ztp log-likelihood
+    obs_keys:
+      - all # Return all columns from the obs dataframe in the output
+      # - cell_type  # Uncomment to only return cell_type column
+      # - tissue  # Uncomment to only return tissue column
+    data_files:
+      - test/data/human_val.h5ad # Path to input AnnData file(s)
+    output_path: ./inference_results # Directory where results will be saved
+    output_filename: embeddings.h5ad # Filename for the output embeddings
+    load_checkpoint: null # Path to model weights file (automatically set by inference.py)
+    pretrained_embedding: null # Path to pretrained embeddings for out-of-distribution species
+    precision: 16-mixed # Numerical precision for inference (16-mixed, 32, etc.)
+
+  data_config:
+    _target_: transcriptformer.data.dataclasses.DataConfig
+    gene_col_name: "ensembl_id" # Column name in AnnData.var containing gene identifiers
+    clip_counts: 30 # Maximum count value (higher values will be clipped)
+    filter_to_vocabs: true # Whether to filter genes to only those in the vocabulary
+    filter_outliers: 0.0 # Standard deviation threshold for filtering outlier cells (0.0 = no filtering)
+    normalize_to_scale: 0 # Scale factor for count normalization (0 = no normalization)
+    sort_genes: false # Whether to sort genes by expression level
+    randomize_genes: false # Whether to randomize gene order
+    min_expressed_genes: 0 # Minimum number of expressed genes required per cell

--- a/download_artifacts.py
+++ b/download_artifacts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+
+"""
+Download and extract TranscriptFormer model artifacts from a public S3 bucket.
+
+This script provides a convenient way to download and extract TranscriptFormer model weights
+from a public S3 bucket. It supports downloading individual models or all models at once,
+with progress indicators for both download and extraction processes.
+
+Usage:
+    python download_artifacts.py [model] [--checkpoint-dir DIR]
+
+    model: The model to download. Options are:
+        - tf-sapiens: Download the sapiens model
+        - tf-exemplar: Download the exemplar model
+        - tf-metazoa: Download the metazoa model
+        - all: Download all models and embeddings
+        - all-embeddings: Download only the embedding files
+
+    --checkpoint-dir: Optional directory to store the downloaded checkpoints.
+                      Defaults to './checkpoints'
+
+Examples
+--------
+    # Download the sapiens model
+    python download_artifacts.py tf-sapiens
+
+    # Download all models and embeddings
+    python download_artifacts.py all
+
+    # Download only the embeddings file
+    python download_artifacts.py all-embeddings
+
+    # Download the exemplar model to a custom directory
+    python download_artifacts.py tf-exemplar --checkpoint-dir /path/to/models
+
+The downloaded models will be extracted to:
+    ./checkpoints/tf_sapiens/
+    ./checkpoints/tf_exemplar/
+    ./checkpoints/tf_metazoa/
+    ./checkpoints/all_embeddings/
+"""
+
+import argparse
+import math
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def print_progress(current, total, prefix="", suffix="", length=50):
+    """Print a simple progress bar."""
+    filled = int(length * current / total)
+    bar = "█" * filled + "░" * (length - filled)
+    percent = math.floor(100 * current / total)
+    print(f"\r{prefix} |{bar}| {percent}% {suffix}", end="", flush=True)
+    if current == total:
+        print()
+
+
+def download_and_extract(model_name: str, checkpoint_dir: str = "./checkpoints"):
+    """Download and extract a model artifact from S3."""
+    s3_path = f"https://czi-transcriptformer.s3.amazonaws.com/weights/{model_name}.tar.gz"
+    output_dir = Path(checkpoint_dir) / model_name
+
+    # Create checkpoint directory if it doesn't exist
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Downloading {model_name} from {s3_path}...")
+
+    try:
+        # Create a temporary file to store the tar.gz
+        with tempfile.NamedTemporaryFile(suffix=".tar.gz") as tmp_file:
+            # Download the file using urllib with progress bar
+            try:
+
+                def report_hook(count, block_size, total_size):
+                    """Callback function to report download progress."""
+                    if total_size > 0:
+                        print_progress(
+                            count * block_size,
+                            total_size,
+                            prefix=f"Downloading {model_name}",
+                        )
+
+                urllib.request.urlretrieve(s3_path, filename=tmp_file.name, reporthook=report_hook)
+                print()  # New line after download completes
+            except urllib.error.HTTPError as e:
+                if e.code == 404:
+                    print(f"Error: The model {model_name} was not found at {s3_path}")
+                else:
+                    print(f"Error downloading file: HTTP {e.code}")
+                sys.exit(1)
+            except urllib.error.URLError as e:
+                print(f"Error downloading file: {str(e)}")
+                sys.exit(1)
+
+            # Reset the file pointer to the beginning
+            tmp_file.seek(0)
+
+            # Extract the tar.gz file
+            try:
+                print(f"Extracting {model_name}...")
+                with tarfile.open(fileobj=tmp_file, mode="r:gz") as tar:
+                    members = tar.getmembers()
+                    total_files = len(members)
+                    for i, member in enumerate(members, 1):
+                        tar.extract(member, path=str(output_dir.parent))
+                        print_progress(
+                            i,
+                            total_files,
+                            prefix=f"Extracting {model_name}",
+                        )
+                print()  # New line after extraction completes
+            except tarfile.ReadError:
+                print(f"Error: The downloaded file for {model_name} is not a valid tar.gz archive")
+                sys.exit(1)
+
+        print(f"Successfully downloaded and extracted {model_name} to {output_dir}")
+
+    except Exception as e:
+        print(f"Error: {str(e)}")
+        sys.exit(1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download and extract TranscriptFormer model artifacts")
+    parser.add_argument(
+        "model",
+        choices=["tf-sapiens", "tf-exemplar", "tf-metazoa", "all", "all-embeddings"],
+        help="Model to download (or 'all' for all models and embeddings, 'all-embeddings' for just embeddings)",
+    )
+    parser.add_argument(
+        "--checkpoint-dir",
+        default="./checkpoints",
+        help="Directory to store the downloaded checkpoints (default: ./checkpoints)",
+    )
+
+    args = parser.parse_args()
+
+    models = {
+        "tf-sapiens": "tf_sapiens",
+        "tf-exemplar": "tf_exemplar",
+        "tf-metazoa": "tf_metazoa",
+        "all-embeddings": "all_embeddings",
+    }
+
+    if args.model == "all":
+        # Download all models and embeddings
+        for model in ["tf_sapiens", "tf_exemplar", "tf_metazoa", "all_embeddings"]:
+            download_and_extract(model, args.checkpoint_dir)
+    elif args.model == "all-embeddings":
+        # Download only embeddings
+        download_and_extract("all_embeddings", args.checkpoint_dir)
+    else:
+        download_and_extract(models[args.model], args.checkpoint_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/inference.py
+++ b/inference.py
@@ -1,0 +1,63 @@
+"""
+Script to perform inference with Transcriptformer models.
+
+Example usage:
+    python inference.py --config-name=inference_config.yaml \
+  model.checkpoint_path=./checkpoints/tf_sapiens \
+  model.inference_config.data_files.0=test/data/human_val.h5ad \
+  model.inference_config.output_path=./custom_results_dir \
+  model.inference_config.output_filename=custom_embeddings.h5ad \
+  model.inference_config.batch_size=8
+"""
+
+import json
+import logging
+import os
+
+import hydra
+from omegaconf import DictConfig, OmegaConf
+
+from transcriptformer.model.inference import run_inference
+
+# Set up logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+
+
+@hydra.main(
+    config_path=os.path.join(os.path.dirname(__file__), "conf"),
+    config_name="inference_config.yaml",
+    version_base=None,
+)
+def main(cfg: DictConfig):
+    logging.debug(OmegaConf.to_yaml(cfg))
+
+    config_path = os.path.join(cfg.model.checkpoint_path, "config.json")
+    with open(config_path) as f:
+        config_dict = json.load(f)
+    mlflow_cfg = OmegaConf.create(config_dict)
+
+    # Merge the MLflow config with the main config
+    cfg = OmegaConf.merge(mlflow_cfg, cfg)
+
+    # Set the checkpoint paths based on the unified checkpoint_path
+    cfg.model.inference_config.load_checkpoint = os.path.join(cfg.model.checkpoint_path, "model_weights.pt")
+    cfg.model.data_config.aux_vocab_path = os.path.join(cfg.model.checkpoint_path, "vocabs")
+    cfg.model.data_config.esm2_mappings_path = os.path.join(cfg.model.checkpoint_path, "vocabs")
+
+    adata_output = run_inference(cfg, data_files=cfg.model.inference_config.data_files)
+
+    # Save the output adata
+    output_path = cfg.model.inference_config.output_path
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+
+    # Get output filename from config or use default
+    output_filename = getattr(cfg.model.inference_config, "output_filename", "embeddings.h5ad")
+    save_file = os.path.join(output_path, output_filename)
+
+    adata_output.write_h5ad(save_file)
+    logging.info(f"Saved embeddings to {save_file}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add back the conf and scripts to root of the repo (duplicate to the ones packaged in `src/`) to ensure that existing tutorials still work for users while we wait to migrate them to use the new CLI merged in #17 