### PR TITLE
fix: issue #20

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,15 +161,13 @@ Input data files should be in H5AD format (AnnData objects) with the following r
   - The column name can be changed using `model.data_config.gene_col_name`
 
 - **Expression Data**: The model expects unnormalized count data and will look for it in the following order:
-  1. `adata.layers['decontX']` (if available)
-  2. `adata.raw.X` (if available)
-  3. `adata.X`
+  1. `adata.raw.X` (if available)
+  2. `adata.X`
 
-  This behavior can be controlled using `model.data_config.anndata_counts_layer`:
-  - `"auto"` (default): Uses the priority order above
-  - `"decontX"`: Uses only `adata.layers['decontX']`
-  - `"raw"`: Uses only `adata.raw.X`
-  - `"X"`: Uses only `adata.X`
+  This behavior can be controlled using `model.data_config.use_raw`:
+  - `None` (default): Try `adata.raw.X` first, then fall back to `adata.X`
+  - `True`: Use only `adata.raw.X`
+  - `False`: Use only `adata.X`
 
 - **Count Processing**:
   - Count values are clipped at 30 by default (as was done in training)

--- a/README.md
+++ b/README.md
@@ -151,19 +151,35 @@ transcriptformer inference --help
 transcriptformer download --help
 ```
 
-### Input Data Format:
+### Input Data Format and Preprocessing:
 
 Input data files should be in H5AD format (AnnData objects) with the following requirements:
 
 - **Gene IDs**: The `var` dataframe must contain an `ensembl_id` column with Ensembl gene identifiers
   - Out-of-vocabulary gene IDs will be automatically filtered out during processing
   - Only genes present in the model's vocabulary will be used for inference
+  - The column name can be changed using `model.data_config.gene_col_name`
 
-- **Expression Data**: Raw count data should be stored in the `adata.X` matrix
-  - The model expects raw (non-normalized) counts
-  - Log-transformed or normalized data may lead to unexpected results
+- **Expression Data**: The model expects unnormalized count data and will look for it in the following order:
+  1. `adata.layers['decontX']` (if available)
+  2. `adata.raw.X` (if available)
+  3. `adata.X`
+
+  This behavior can be controlled using `model.data_config.anndata_counts_layer`:
+  - `"auto"` (default): Uses the priority order above
+  - `"decontX"`: Uses only `adata.layers['decontX']`
+  - `"raw"`: Uses only `adata.raw.X`
+  - `"X"`: Uses only `adata.X`
+
+- **Count Processing**:
+  - Count values are clipped at 30 by default (as was done in training)
+  - If this seems too low, you can either:
+    1. Use `model.data_config.normalize_to_scale` to scale total counts to a specific value (e.g., 1e3-1e4)
+    2. Increase `model.data_config.clip_counts` to a value > 30
 
 - **Cell Metadata**: Any cell metadata in the `obs` dataframe will be preserved in the output
+
+No other data preprocessing is necessary - the model handles all required transformations internally. You do not need to perform any additional normalization, scaling, or transformation of the count data before input.
 
 ### Output Format:
 

--- a/conf/inference_config.yaml
+++ b/conf/inference_config.yaml
@@ -32,3 +32,4 @@ model:
     sort_genes: false # Whether to sort genes by expression level
     randomize_genes: false # Whether to randomize gene order
     min_expressed_genes: 0 # Minimum number of expressed genes required per cell
+    anndata_counts_layer: "auto" # Layer in AnnData to use for inference, should be one of "auto", "X", "raw", "decontX"

--- a/conf/inference_config.yaml
+++ b/conf/inference_config.yaml
@@ -32,4 +32,4 @@ model:
     sort_genes: false # Whether to sort genes by expression level
     randomize_genes: false # Whether to randomize gene order
     min_expressed_genes: 0 # Minimum number of expressed genes required per cell
-    anndata_counts_layer: "auto" # Layer in AnnData to use for inference, should be one of "auto", "X", "raw", "decontX"
+    use_raw: "auto" # Whether to use .raw.X (True), .X (False), or auto-detect (auto/null)

--- a/src/transcriptformer/cli/__init__.py
+++ b/src/transcriptformer/cli/__init__.py
@@ -133,6 +133,12 @@ def setup_inference_parser(subparsers):
         default=True,
         help="Whether to filter genes to only those in the vocabulary (default: True)",
     )
+    parser.add_argument(
+        "--use-raw",
+        type=lambda x: None if x.lower() == "auto" else x.lower() == "true",
+        default=None,
+        help="Whether to use raw counts from AnnData.raw.X (True), adata.X (False), or auto-detect (None/auto) (default: None)",
+    )
 
     # Allow arbitrary config overrides
     parser.add_argument(

--- a/src/transcriptformer/cli/conf/inference_config.yaml
+++ b/src/transcriptformer/cli/conf/inference_config.yaml
@@ -32,3 +32,4 @@ model:
     sort_genes: false # Whether to sort genes by expression level
     randomize_genes: false # Whether to randomize gene order
     min_expressed_genes: 0 # Minimum number of expressed genes required per cell
+    use_raw: "auto" # Whether to use .raw.X (True), .X (False), or auto-detect (auto/null)

--- a/src/transcriptformer/data/dataclasses.py
+++ b/src/transcriptformer/data/dataclasses.py
@@ -1,7 +1,6 @@
 """Dataclasses for the Transcripformer model."""
 
 from dataclasses import dataclass, field
-from typing import Literal
 
 import numpy as np
 import torch
@@ -140,7 +139,9 @@ class DataConfig:
     esm2_mappings: list[str] | None = None
     special_tokens: list[str] | None = None
     esm2_mappings_path: str | None = None
-    anndata_counts_layer: Literal["auto", "X", "raw", "decontX"] = "auto"
+    use_raw: bool | None = (
+        None  # If True, use adata.raw.X, if False use adata.X, if None try raw first then fallback to X
+    )
 
 
 # Parameters that control the loss function

--- a/src/transcriptformer/data/dataclasses.py
+++ b/src/transcriptformer/data/dataclasses.py
@@ -1,6 +1,7 @@
 """Dataclasses for the Transcripformer model."""
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 import numpy as np
 import torch
@@ -139,6 +140,7 @@ class DataConfig:
     esm2_mappings: list[str] | None = None
     special_tokens: list[str] | None = None
     esm2_mappings_path: str | None = None
+    anndata_counts_layer: Literal["auto", "X", "raw", "decontX"] = "auto"
 
 
 # Parameters that control the loss function

--- a/src/transcriptformer/data/dataloader.py
+++ b/src/transcriptformer/data/dataloader.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import random
-from typing import Literal
 
 import anndata
 import numpy as np
@@ -176,7 +175,6 @@ class AnnDataset(Dataset):
         clip_counts: float = 1e10,
         inference: bool = False,
         obs_keys: list[str] = None,
-        anndata_counts_layer: Literal["auto", "X", "raw", "decontX"] = "auto",
         use_raw: bool = None,
     ):
         super().__init__()
@@ -198,7 +196,6 @@ class AnnDataset(Dataset):
         self.clip_counts = clip_counts
         self.inference = inference
         self.obs_keys = obs_keys
-        self.anndata_counts_layer = anndata_counts_layer
         self.use_raw = use_raw
 
         self.gene_tokenizer = BatchGeneTokenizer(gene_vocab)

--- a/src/transcriptformer/data/dataloader.py
+++ b/src/transcriptformer/data/dataloader.py
@@ -246,7 +246,7 @@ class AnnDataset(Dataset):
             raise ValueError(f"Invalid counts layer specified: {self.anndata_counts_layer}")
 
     def _to_dense(self, X: np.ndarray | csr_matrix | csc_matrix) -> np.ndarray:
-        if isinstance(X, (csr_matrix, csc_matrix)):
+        if isinstance(X, csr_matrix | csc_matrix):
             return X.toarray()
         elif isinstance(X, np.ndarray):
             return X

--- a/src/transcriptformer/data/dataloader.py
+++ b/src/transcriptformer/data/dataloader.py
@@ -210,37 +210,37 @@ class AnnDataset(Dataset):
 
     def _get_counts_layer(self, adata: anndata.AnnData) -> str:
         if self.anndata_counts_layer == "auto":
-            if hasattr(adata, "layers") and "decontXcounts" in adata.layers:
+            if "decontXcounts" in adata.layers:
                 logging.info("Using 'decontXcounts' layer from AnnData object")
                 return adata.layers["decontXcounts"]
-            elif hasattr(adata, "layers") and "decontX" in adata.layers:
+            elif "decontX" in adata.layers:
                 logging.info("Using 'decontX' layer from AnnData object")
                 return adata.layers["decontX"]
-            elif hasattr(adata, "raw") and adata.raw is not None:
+            elif adata.raw is not None:
                 logging.info("Using 'raw.X' layer from AnnData object")
                 return adata.raw.X
-            elif hasattr(adata, "X") and adata.X is not None:
+            elif adata.X is not None:
                 logging.info("Using 'X' layer from AnnData object")
                 return adata.X
             else:
                 raise ValueError("No valid data layer found in AnnData object")
         elif self.anndata_counts_layer == "decontX":
-            if hasattr(adata, "layers") and "decontXcounts" in adata.layers:
+            if "decontXcounts" in adata.layers:
                 logging.info("Using 'decontXcounts' layer from AnnData object")
                 return adata.layers["decontXcounts"]
-            elif hasattr(adata, "layers") and "decontX" in adata.layers:
+            elif "decontX" in adata.layers:
                 logging.info("Using 'decontX' layer from AnnData object")
                 return adata.layers["decontX"]
             else:
                 raise ValueError("decontXcounts or decontX layer not found in AnnData object")
         elif self.anndata_counts_layer == "raw":
-            if hasattr(adata, "raw") and adata.raw is not None:
+            if adata.raw is not None:
                 logging.info("Using 'raw.X' layer from AnnData object")
                 return adata.raw.X
             else:
                 raise ValueError("raw.X not found in AnnData object")
         elif self.anndata_counts_layer == "X":
-            if hasattr(adata, "X") and adata.X is not None:
+            if adata.X is not None:
                 logging.info("Using 'X' layer from AnnData object")
                 return adata.X
             else:

--- a/src/transcriptformer/model/inference.py
+++ b/src/transcriptformer/model/inference.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 import anndata
 import pandas as pd
@@ -33,6 +34,10 @@ def run_inference(cfg, data_files: list[str] | list[anndata.AnnData]):
     Returns:
         AnnData: Processed data with embeddings and likelihood scores
     """
+    warnings.filterwarnings(
+        "ignore", message="The 'predict_dataloader' does not have many workers which may be a bottleneck"
+    )
+
     # Load vocabs and embeddings
     (gene_vocab, aux_vocab), emb_matrix = load_vocabs_and_embeddings(cfg)
 


### PR DESCRIPTION
## Description 
This PR is to address the issue #20  that the default count matrix adata.X is often normalized data rather than the raw counts. 

## Changes
- Added _get_counts_layer to dataloader function to check for adata.layers['decontX'] > adata.raw.X > adata.X 
- Added _to_dense to dataloader raise an error if data is not a known sparse matrix format 
- Added _is_raw_counts in dataloader to check if counts are raw (with warning if not) 
- Added config option model.data_config.anndata_counts_layer to set count layer with "auto" option as default
- Remove version numbers from ensemble IDs (necessary for TSv2 data) 
- Updated README with clearer preprocessing instructions 