### PR TITLE
improvements to expose configurable backend "device" and disabling of pytorch "compile"

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more details, please refer to our manuscript: [A Cross-Species Generative Ce
 
 ## Installation
 
-Transcriptformer requires Python >=3.11.
+Transcriptformer requires Python >=3.11. Instruction below is based on [*uv* package manager (install instruction here)](https://docs.astral.sh/uv/getting-started/installation/).
 
 ### Install from PyPI
 

--- a/src/transcriptformer/cli/conf/inference_config.yaml
+++ b/src/transcriptformer/cli/conf/inference_config.yaml
@@ -24,6 +24,7 @@ model:
     precision: 16-mixed # Numerical precision for inference (16-mixed, 32, etc.)
     emb_type: cell # Type of embeddings to extract: "cell" for mean-pooled cell embeddings or "cge" for contextual gene embeddings
     num_gpus: 1 # Number of GPUs to use for inference (1 = single GPU, -1 = all available GPUs, >1 = specific number)
+    device: auto # Specific device to use: "auto" (best available), "cpu", "cuda", "mps"
     use_oom_dataloader: false # Use OOM-safe map-style DataLoader with DistributedSampler
 
   data_config:

--- a/src/transcriptformer/cli/inference.py
+++ b/src/transcriptformer/cli/inference.py
@@ -7,7 +7,14 @@ Example usage:
   model.inference_config.data_files.0=test/data/human_val.h5ad \
   model.inference_config.output_path=./custom_results_dir \
   model.inference_config.output_filename=custom_embeddings.h5ad \
-  model.inference_config.batch_size=8
+  model.inference_config.batch_size=8 \
+  model.inference_config.device=cuda
+
+Device options:
+  - auto: Automatically select best available device (default)
+  - cpu: Force CPU usage
+  - cuda: Force CUDA/GPU usage (requires CUDA availability)
+  - mps: Force MPS usage for Apple Silicon
 """
 
 import json

--- a/src/transcriptformer/data/dataclasses.py
+++ b/src/transcriptformer/data/dataclasses.py
@@ -32,6 +32,7 @@ class ModelConfig:
         block_len (int): Block length for Flex attention (default: 128)
         use_aux (bool): Use auxiliary inputs flag (default: false)
         gene_head_hidden_dim (int): Gene head hidden dimension (default: 2048)
+        compile_block_mask (bool): Whether to compile block mask creation for performance (default: true)
     """
 
     log_counts_eps: float
@@ -52,6 +53,7 @@ class ModelConfig:
     # Optional fields
     gene_head_hidden_dim: int = 2048
     use_aux: bool = False
+    compile_block_mask: bool = True
 
     def __post_init__(self):
         if (self.seq_len + self.aux_len) % self.block_len != 0:
@@ -178,6 +180,7 @@ class InferenceConfig:
         output_path (str): Path to save outputs
         output_filename (str): Filename for the output embeddings (default: embeddings.h5ad)
         num_gpus (int): Number of GPUs to use for inference (1 = single GPU, -1 = all available GPUs, >1 = specific number) (default: 1)
+        device (str): Specific device to use for inference ("auto", "cpu", "cuda", "mps") (default: "auto")
         special_tokens (list): Special tokens to use
         emb_type (str): Type of embeddings to extract - "cell" for mean-pooled cell embeddings or "cge" for contextual gene embeddings (default: "cell")
     """
@@ -190,6 +193,7 @@ class InferenceConfig:
     output_path: str | None
     output_filename: str | None = "embeddings.h5ad"
     num_gpus: int = 1
+    device: str = "auto"
     num_nodes: int = 1
     use_oom_dataloader: bool = False
     precision: str = "16-mixed"
@@ -200,6 +204,8 @@ class InferenceConfig:
     def __post_init__(self):
         if self.emb_type not in {"cell", "cge"}:
             raise ValueError("emb_type must be either 'cell' or 'cge'")
+        if self.device not in {"auto", "cpu", "cuda", "mps"}:
+            raise ValueError("device must be one of ['auto', 'cpu', 'cuda', 'mps']")
 
 
 @dataclass

--- a/src/transcriptformer/model/embedding_surgery.py
+++ b/src/transcriptformer/model/embedding_surgery.py
@@ -32,9 +32,11 @@ def change_embedding_layer(
         [model.gene_vocab.vocab_dict[token] for token in old_special_tokens],
         dtype=torch.int64,
     )
-    # Move model to GPU - needed if model is not re-loaded from checkpoint
-    model = model.to("cuda")
-    old_special_token_embeddings = model.gene_embeddings.embedding(old_special_token_indices.to("cuda"))
+    # Move model to the appropriate device - needed if model is not re-loaded from checkpoint
+    # Get the device from the model's existing parameters
+    device = next(model.parameters()).device
+    model = model.to(device)
+    old_special_token_embeddings = model.gene_embeddings.embedding(old_special_token_indices.to(device))
 
     # Read the new embeddings from the files
     gene_vocab, new_embedding_matrix = construct_gene_embeddings(
@@ -44,7 +46,7 @@ def change_embedding_layer(
 
     # Concatenate the old special token embeddings with the new embeddings
     new_embedding_matrix = torch.cat(
-        [old_special_token_embeddings, torch.Tensor(new_embedding_matrix).to("cuda")],
+        [old_special_token_embeddings, torch.Tensor(new_embedding_matrix).to(device)],
         dim=0,
     )
 

--- a/src/transcriptformer/model/model.py
+++ b/src/transcriptformer/model/model.py
@@ -134,6 +134,7 @@ class Transcriptformer(pl.LightningModule):
             activation=self.model_config.activation,
             attn_bias=self.model_config.attn_bias,
             fw_bias=self.model_config.fw_bias,
+            compile_attention=self.model_config.compile_block_mask,
         )
 
     def _init_count_heads(self):
@@ -302,8 +303,9 @@ class Transcriptformer(pl.LightningModule):
             H=None,
             Q_LEN=right_shifted_gene_embeddings.shape[1],
             KV_LEN=right_shifted_gene_embeddings.shape[1],
+            device=right_shifted_gene_embeddings.device,
             BLOCK_SIZE=self.model_config.block_len,
-            _compile=True,
+            _compile=self.model_config.compile_block_mask,
         )
 
         # Score mode


### PR DESCRIPTION
Current codebase hardcodes "cuda" as the backend device for running inference. Additionally, tensor and model embedding are pre-compiled (for performance gain); however, torch compile is not supported on all hardware architecture (i.e. Apple Silicon). Therefore, current inference call using the example provided will fail on compute hardware that lacks "cuda" kernel support. The changes introduced here accomplish a few things:

1. expose backend `device` configuration in CLI and in yaml config file ("auto", "cuda", "cpu", "mps")
2. expose pytorch compile step as a configurable parameter in CLI and in yaml config file (defaults to "True" for compiling torch tensors)
3. the default values for these parameters are chosen in such a way to maintain consistent behavior with the current version

summary of changes:
- Added `device` parameter to `InferenceConfig` with choices: `"auto"`, `"cpu"`, `"cuda"`, `"mps"`
- Implemented comprehensive device preference handling in inference logic (if device == "auto" -> "cuda" > "cpu")
- Added device validation and error handling for unavailable devices, with enhanced checkpoint loading with proper `map_location` to avoid device conflicts
- Added `compile_block_mask` parameter to `ModelConfig` (default: `True`)
- Made block mask compilation configurable via `create_block_mask(_compile=...)` parameter
- Added `compile_attention` parameter throughout the attention layer hierarchy:
  - `MultiHeadSelfFlexAttn` class
  - `FlexAttnTransformerLayer` class
  - `TranscriptEncoder` class
- Added `--device` CLI argument with choices: `auto`, `cpu`, `cuda`, `mps`
- Added `--disable-compile-block-mask` CLI flag for easy compilation control

I have run the current test suite and can confirm they all passed.
